### PR TITLE
Fix/resume mobile

### DIFF
--- a/app/components/site-header.tsx
+++ b/app/components/site-header.tsx
@@ -53,7 +53,7 @@ export default function SiteHeader(): React.ReactElement {
         Skip to content
       </a>
 
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 md:px-10 lg:px-14">
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6 md:px-10 lg:px-14">
         <a
           href="/"
           onClick={(e) => handleSiteNameClick(e)}

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -74,8 +74,8 @@ export default function ResumePage({ loaderData }: Route.ComponentProps) {
             </h2>
             <div className="mt-4 flex flex-col gap-3">
               {resume.skills.map((group) => (
-                <div key={group.label} className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                  <span className="text-sm font-medium w-40 shrink-0">
+                <div key={group.label} className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-x-2">
+                  <span className="text-sm font-medium sm:w-40 sm:shrink-0">
                     {group.label}
                   </span>
                   <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
### Changes
- Make header height consistent between resume and home route in mobile
- Place list of skills underneath title on small viewports